### PR TITLE
Added function #calendarView.resetDisabledDays()

### DIFF
--- a/cosmocalendar/src/main/java/com/applikeysolutions/cosmocalendar/adapter/MonthAdapter.java
+++ b/cosmocalendar/src/main/java/com/applikeysolutions/cosmocalendar/adapter/MonthAdapter.java
@@ -144,6 +144,16 @@ public class MonthAdapter extends RecyclerView.Adapter<MonthHolder> {
         notifyDataSetChanged();
     }
 
+
+    public void resetDisabledDays() {
+        for (Month month : months) {
+            for (Day day : month.getDays()) {
+                day.setDisabled(false);
+            }
+        }
+        notifyDataSetChanged();
+    }
+
     private void setDaysAccordingToSet(Set<Long> days, DayFlag dayFlag) {
         if (days != null && !days.isEmpty()) {
             for (Month month : months) {

--- a/cosmocalendar/src/main/java/com/applikeysolutions/cosmocalendar/view/CalendarView.java
+++ b/cosmocalendar/src/main/java/com/applikeysolutions/cosmocalendar/view/CalendarView.java
@@ -542,6 +542,14 @@ public class CalendarView extends RelativeLayout implements OnDaySelectedListene
         monthAdapter.setWeekendDays(weekendDays);
     }
 
+    /**
+     * re-Enables the already disabled days if wants to toggle
+     */
+    public void resetDisabledDays()
+    {
+        monthAdapter.resetDisabledDays();
+    }
+
     @Override
     public void setDisabledDaysCriteria(DisabledDaysCriteria criteria) {
         settingsManager.setDisabledDaysCriteria(criteria);


### PR DESCRIPTION
Added function #calendarView.resetDisabledDays() to reset disabled days in the calendar. As Described in the below issue

#https://github.com/ApplikeySolutions/CosmoCalendar/issues/28

Feature case:

If user wants to toggle between saturday as disabled/Enabled on run time instead of pre-initializing. Then calendarView.resetDisabledDays() method can be used.